### PR TITLE
Add missing negative sign

### DIFF
--- a/orthogonality/projection.md
+++ b/orthogonality/projection.md
@@ -166,7 +166,7 @@ as in the previous example. Compute
 $$
 P_{\perp} = I - P =
 \left[ \begin{array}{rrr} 1 & 0 & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 1 \end{array} \right] -
-\frac{1}{6} \left[ \begin{array}{rrr} 5 & 2 & 1 \\ 2 & 2 & 2 \\ -1 & 2 & 5 \end{array} \right]
+\frac{1}{6} \left[ \begin{array}{rrr} 5 & 2 & -1 \\ 2 & 2 & 2 \\ -1 & 2 & 5 \end{array} \right]
 =
 \frac{1}{6} \left[ \begin{array}{rrr} 1 & -2 & -1 \\ -2 & 4 & -2 \\ 1 & -2 & 1 \end{array} \right]
 $$


### PR DESCRIPTION
- example for projecting onto the complementary subspace was using
matrix from previous example, but was incorrectly copied over (missing
negative sign in the very top right position)