### PR TITLE
fix error in example 3 of odes.md

### DIFF
--- a/systems/odes.md
+++ b/systems/odes.md
@@ -223,7 +223,7 @@ $$
 \end{array} \right]
 \begin{bmatrix} y_1 \\ y_2 \\ y_3 \\ y_4 \\ y_5 \end{bmatrix}
 =
-\begin{bmatrix} \pi^2/18 \\ -\pi^2/18 \\ -1 \\ -\pi^2/18 \\ \pi^2/18 - 1 \end{bmatrix}
+\begin{bmatrix} \pi^2/18 \\ -\pi^2/18 \\ -\pi^2/9 \\ -\pi^2/18 \\ \pi^2/18 - 1 \end{bmatrix}
 $$
 
 Use `scipy.linalg.solve` to compute the solution. The equation is elementary and we can solve exactly by integrating twice


### PR DESCRIPTION
Fixed error in calculation for b_3 in example 3 of the Differential Equations section. 

Credit to anonymous Piazza post, -1 should be multiplied by h^2 to isolate y_2 - 2y_3 + y_4, so b_3 = -pi^2/9 not -1

I updated this while studying for the midterm so hopefully I'm correct...